### PR TITLE
Travis has Composer built-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.4
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - composer install --dev
 
 script: phpunit


### PR DESCRIPTION
See [Travis docs](http://about.travis-ci.org/docs/user/languages/php/#Installing-Composer-packages) : Composer is built-in PHP environnement, no need to load it beforehand.
