### PR TITLE
[L5] Allow workbench to work inside of L5 install

### DIFF
--- a/stubs/composer.json
+++ b/stubs/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.*"
+        "illuminate/support": "5.0.*@dev"
     },
     "autoload": {
         "classmap": [
@@ -19,5 +19,5 @@
             "{{vendor}}\\{{name}}\\": "src/"
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
Error prior to this

```
Package workbench created!

Loading composer repositories with package information
Installing dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package illuminate/support could not be found in any version, there may be a typo in the package name.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```
